### PR TITLE
Project configuration

### DIFF
--- a/app/sales-api/main.go
+++ b/app/sales-api/main.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"expvar"
+	"fmt"
 	"log"
 	"os"
+	"time"
+
+	"github.com/ardanlabs/conf"
+	"github.com/pkg/errors"
 )
+
+// build is the git version of this program. It is set using build flags in the makefile.
+var build = "develop"
 
 func main() {
 	log := log.New(os.Stdout, "SALES : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
@@ -14,5 +23,73 @@ func main() {
 }
 
 func run(l *log.Logger) error {
+	cfg := struct {
+		conf.Version
+		Web struct {
+			APIHost         string        `conf:"default:0.0.0.0:3000"`
+			DebugHost       string        `conf:"default:0.0.0.0:4000"`
+			ReadTimeout     time.Duration `conf:"default:5s"`
+			WriteTimeout    time.Duration `conf:"default:10s"`
+			IdleTimeout     time.Duration `conf:"default:120s"`
+			ShutdownTimeout time.Duration `conf:"default:20s"`
+		}
+		Auth struct {
+			KeysFolder string `conf:"default:zarf/keys/"`
+			Algorithm  string `conf:"default:RS256"`
+		}
+		DB struct {
+			User         string `conf:"default:postgres"`
+			Password     string `conf:"default:postgres,mask"`
+			Host         string `conf:"default:db"`
+			Name         string `conf:"default:postgres"`
+			MaxIdleConns int    `conf:"default:0"`
+			MaxOpenConns int    `conf:"default:0"`
+			DisableTLS   bool   `conf:"default:true"`
+		}
+		Zipkin struct {
+			ReporterURI string  `conf:"default:http://localhost:9411/api/v2/spans"`
+			ServiceName string  `conf:"default:sales-api"`
+			Probability float64 `conf:"default:0.05"`
+		}
+	}{
+		Version: conf.Version{
+			SVN:  build,
+			Desc: "copyright information here",
+		},
+	}
+
+	const prefix = "SALES"
+	if err := conf.Parse(os.Args[1:], prefix, &cfg); err != nil {
+		switch err {
+		case conf.ErrHelpWanted:
+			usage, err := conf.Usage(prefix, &cfg)
+			if err != nil {
+				return errors.Wrap(err, "generating config usage")
+			}
+			fmt.Println(usage)
+			return nil
+		case conf.ErrVersionWanted:
+			version, err := conf.VersionString(prefix, &cfg)
+			if err != nil {
+				return errors.Wrap(err, "generating config version")
+			}
+			fmt.Println(version)
+			return nil
+		}
+		return errors.Wrap(err, "parsing config")
+	}
+
+	// =========================================================================
+	// App Starting
+	expvar.NewString("build").Set(build)
+	log.Println("starting service", "version", build)
+	defer log.Println("shutdown complete")
+
+	out, err := conf.String(&cfg)
+	if err != nil {
+		return errors.Wrap(err, "generating config for output")
+	}
+	log.Println("startup", "config", out)
+
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/enriquesalceda/service
 
 go 1.16
+
+require (
+	github.com/ardanlabs/conf v1.4.0
+	github.com/pkg/errors v0.9.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/ardanlabs/conf v1.4.0 h1:Nzi1Z5TBlwdNNYTSjfm26NL3C8kbVCZhEnJ7kiyONdY=
+github.com/ardanlabs/conf v1.4.0/go.mod h1:ILsMo9dMqYzCxDjDXTiwMI0IgxOJd0MOiucbQY2wlJw=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/makefile
+++ b/makefile
@@ -1,0 +1,8 @@
+SHELL := /bin/zsh
+
+run:
+	go run app/sales-api/main.go
+
+tidy:
+	go mod tidy
+	go mod vendor


### PR DESCRIPTION
# Configuration

> You can start a project without understanding how configuration is going to work.

Key points:
* Each configuration value should have a default value that works in `develop` (There are exceptions like API keys).
* Only the `main.go`  is allowed to import and hit the configuration system. Not other package is allowed to talk to the configuration system, use config `structs` or `parameters`.
* For this project we use config to pass the data to the `main()` function.
* The developer should be able to update the environment variables through the CLI for experimentation, debugging, quick prototyping.

We are using the [CONF](https://github.com/ardanlabs/conf) package from Ardan Labs. This package provides support for using environmental variables and command line arguments for configuration. There are no hard bindings for this package. This package takes a struct value and parses it for both the environment and flags. It supports several tags to customise the flag options.

It sets the structs to provide the environment variables.

```Go
cfg := struct {
		conf.Version
		Web struct {
			APIHost         string        `conf:"default:0.0.0.0:3000"`
			DebugHost       string        `conf:"default:0.0.0.0:4000"`
			ReadTimeout     time.Duration `conf:"default:5s"`
			WriteTimeout    time.Duration `conf:"default:10s"`
			IdleTimeout     time.Duration `conf:"default:120s"`
			ShutdownTimeout time.Duration `conf:"default:20s"`
		}
		Auth struct {
			KeysFolder string `conf:"default:zarf/keys/"`
			Algorithm  string `conf:"default:RS256"`
		}
... it continues ...
```

The code below parses is the `--help` or `--version` wanted

```Go
	if err := conf.Parse(os.Args[1:], prefix, &cfg); err != nil {
		switch err {
		case conf.ErrHelpWanted:
			usage, err := conf.Usage(prefix, &cfg)
			if err != nil {
				return errors.Wrap(err, "generating config usage")
			}
			fmt.Println(usage)
			return nil
		case conf.ErrVersionWanted:
			version, err := conf.VersionString(prefix, &cfg)
			if err != nil {
				return errors.Wrap(err, "generating config version")
			}
			fmt.Println(version)
			return nil
		}
		return errors.Wrap(err, "parsing config")
	}
```

You can run those commands like this:

1. Go to the sales api directory and build the go code.
2. Then, `./sales-api --help `, which will return this:

```shell
Usage: sales-api [options] [arguments]

OPTIONS
  --web-api-host/$SALES_WEB_API_HOST                  <string>    (default: 0.0.0.0:3000)
  --web-debug-host/$SALES_WEB_DEBUG_HOST              <string>    (default: 0.0.0.0:4000)
  --web-read-timeout/$SALES_WEB_READ_TIMEOUT          <duration>  (default: 5s)
  --web-write-timeout/$SALES_WEB_WRITE_TIMEOUT        <duration>  (default: 10s)
  --web-idle-timeout/$SALES_WEB_IDLE_TIMEOUT          <duration>  (default: 120s)
  --web-shutdown-timeout/$SALES_WEB_SHUTDOWN_TIMEOUT  <duration>  (default: 20s)
  --auth-keys-folder/$SALES_AUTH_KEYS_FOLDER          <string>    (default: zarf/keys/)
  --auth-algorithm/$SALES_AUTH_ALGORITHM              <string>    (default: RS256)
  --db-user/$SALES_DB_USER                            <string>    (default: postgres)
  --db-password/$SALES_DB_PASSWORD                    <string>    (default: postgres)
  --db-host/$SALES_DB_HOST                            <string>    (default: db)
  --db-name/$SALES_DB_NAME                            <string>    (default: postgres)
  --db-max-idle-conns/$SALES_DB_MAX_IDLE_CONNS        <int>       (default: 0)
  --db-max-open-conns/$SALES_DB_MAX_OPEN_CONNS        <int>       (default: 0)
  --db-disable-tls/$SALES_DB_DISABLE_TLS              <bool>      (default: true)
  --zipkin-reporter-uri/$SALES_ZIPKIN_REPORTER_URI    <string>    (default: http://localhost:9411/api/v2/spans)
  --zipkin-service-name/$SALES_ZIPKIN_SERVICE_NAME    <string>    (default: sales-api)
  --zipkin-probability/$SALES_ZIPKIN_PROBABILITY      <float>     (default: 0.05)
  --help/-h                                           
  display this help message
  --version/-v  
  display version information
```

For version:

1. `./sales-api --version`, then you'll see this:

```shell
Version: develop
copyright information here
```

## Extras
There is a new `makefile` with the specific targets to run key commands to run our application.